### PR TITLE
[Create Question] Change ACL for nav button actions from private to internal

### DIFF
--- a/Polls/ViewControllers/CreateQuestionViewController.swift
+++ b/Polls/ViewControllers/CreateQuestionViewController.swift
@@ -36,11 +36,11 @@ class CreateQuestionViewController : UITableViewController {
     validate()
   }
 
-  private func close(sender:AnyObject) {
+  func close(sender:AnyObject) {
     dismissViewControllerAnimated(true, completion: nil)
   }
 
-  private func save(sender:AnyObject) {
+  func save(sender:AnyObject) {
     SVProgressHUD.showInfoWithStatus(NSLocalizedString("QUESTION_CREATE_CREATING", comment: ""), maskType: .Gradient)
 
     func nonEmpty(choice:String) -> Bool {


### PR DESCRIPTION
While being private apparently means UIKit (the navigation bar button item) cannot call these them. In a recent commit where I cleaned up the internal API to make various methods private and introduced a bug where tapping the cancel button would cause an application crash.
