### PR TITLE
Smooth transition clearing selection on appearance

### DIFF
--- a/Polls/ViewControllers/QuestionListViewController.swift
+++ b/Polls/ViewControllers/QuestionListViewController.swift
@@ -26,6 +26,20 @@ class QuestionListViewController : UITableViewController, QuestionDetailViewCont
     loadData()
   }
 
+  override func viewWillAppear(animated: Bool) {
+    super.viewWillAppear(animated)
+
+    if let selectedIndex = tableView.indexPathForSelectedRow() {
+      tableView.deselectRowAtIndexPath(selectedIndex, animated: animated)
+
+      transitionCoordinator()?.notifyWhenInteractionEndsUsingBlock { context in
+        if context.isCancelled() {
+          self.tableView.selectRowAtIndexPath(selectedIndex, animated: false, scrollPosition: .None)
+        }
+      }
+    }
+  }
+
   // MARK: Other
 
   func loadData() {


### PR DESCRIPTION
These changes resolve a subtle bug during animation of the selected cell when transitioning from the question detail view controller back to the question list view controller.