### PR TITLE
Add pull to refresh on question detail screen providing the server exposes a self transition

### DIFF
--- a/Polls/ViewControllers/QuestionDetailViewController.swift
+++ b/Polls/ViewControllers/QuestionDetailViewController.swift
@@ -16,7 +16,7 @@ class QuestionDetailViewController : UITableViewController {
   var viewModel:QuestionDetailViewModel? {
     didSet {
       if isViewLoaded() {
-        tableView.reloadData()
+        updateState()
       }
     }
   }
@@ -26,6 +26,7 @@ class QuestionDetailViewController : UITableViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     title = NSLocalizedString("QUESTION_DETAIL_TITLE", comment: "")
+    updateState()
   }
 
   // MARK: UITableViewDelegate
@@ -87,6 +88,30 @@ class QuestionDetailViewController : UITableViewController {
     viewModel?.vote(index) { voted in
       SVProgressHUD.dismiss()
       self.tableView.reloadData()
+    }
+  }
+
+  func updateState() {
+    if viewModel?.canReload ?? false {
+      if refreshControl == nil {
+        refreshControl = UIRefreshControl()
+        refreshControl?.addTarget(self, action:Selector("reload"), forControlEvents:.ValueChanged)
+      }
+    } else {
+      refreshControl = nil
+    }
+
+    tableView?.reloadData()
+  }
+
+  func reload() {
+    if let viewModel = viewModel {
+      viewModel.reload { result in
+        self.refreshControl?.endRefreshing()
+        self.updateState()
+      }
+    } else {
+      refreshControl?.endRefreshing()
     }
   }
 }

--- a/Polls/ViewControllers/QuestionListViewController.swift
+++ b/Polls/ViewControllers/QuestionListViewController.swift
@@ -133,7 +133,7 @@ class QuestionListViewController : UITableViewController, QuestionDetailViewCont
   // MARK: QuestionDetailViewControllerDelegate
 
   func didCreateQuestion(viewController:CreateQuestionViewController) {
-    loadData()
+    tableView?.reloadData()
   }
 
   // MARK: UserPreferenceViewControllerDelegate

--- a/Polls/ViewModels/CreateQuestionViewModel.swift
+++ b/Polls/ViewModels/CreateQuestionViewModel.swift
@@ -13,12 +13,16 @@ import Hyperdrive
 
 /// A view model for creating a question
 class CreateQuestionViewModel {
+  typealias DidAddCallback = (Representor<HTTPTransition>) -> ()
+
+  private let didAddCallback:DidAddCallback?
   private let hyperdrive:Hyperdrive
   private var transition:HTTPTransition
 
-  init(hyperdrive:Hyperdrive, transition:HTTPTransition) {
+  init(hyperdrive:Hyperdrive, transition:HTTPTransition, didAddCallback:DidAddCallback? = nil) {
     self.hyperdrive = hyperdrive
     self.transition = transition
+    self.didAddCallback = didAddCallback
   }
 
   /// Validates if the given question is valid
@@ -38,6 +42,7 @@ class CreateQuestionViewModel {
     hyperdrive.request(transition, attributes: ["question": question, "choices": choices]) { result in
       switch result {
       case .Success(let representor):
+        self.didAddCallback?(representor)
         completion()
       case .Failure(let error):
         println("Failure \(error)")

--- a/Polls/ViewModels/QuestionDetailViewModel.swift
+++ b/Polls/ViewModels/QuestionDetailViewModel.swift
@@ -16,6 +16,25 @@ class QuestionDetailViewModel {
   private let hyperdrive:Hyperdrive
   private var representor:Representor<HTTPTransition>
 
+  var canReload:Bool {
+    return self.representor.transitions["self"] != nil
+  }
+
+  func reload(completion:((Result) -> ())) {
+    if let uri = self.representor.transitions["self"] {
+      hyperdrive.request(uri) { result in
+        switch result {
+        case .Success(let representor):
+          self.representor = representor
+        case .Failure(let error):
+          break
+        }
+
+        completion(result)
+      }
+    }
+  }
+
   private var choices:[Representor<HTTPTransition>] {
     return representor.representors["choices"] ?? []
   }

--- a/Polls/ViewModels/QuestionDetailViewModel.swift
+++ b/Polls/ViewModels/QuestionDetailViewModel.swift
@@ -13,6 +13,9 @@ import Hyperdrive
 
 /// View model for a specific question
 class QuestionDetailViewModel {
+  typealias DidUpdateCallback = (Representor<HTTPTransition>) -> ()
+
+  private let didUpdateCallback:DidUpdateCallback?
   private let hyperdrive:Hyperdrive
   private var representor:Representor<HTTPTransition>
 
@@ -26,6 +29,7 @@ class QuestionDetailViewModel {
         switch result {
         case .Success(let representor):
           self.representor = representor
+          self.didUpdateCallback?(representor)
         case .Failure(let error):
           break
         }
@@ -44,9 +48,10 @@ class QuestionDetailViewModel {
     return representor.attributes["question"] as? String ?? "Question"
   }
 
-  init(hyperdrive:Hyperdrive, representor:Representor<HTTPTransition>) {
+  init(hyperdrive:Hyperdrive, representor:Representor<HTTPTransition>, didUpdateCallback:DidUpdateCallback? = nil) {
     self.hyperdrive = hyperdrive
     self.representor = representor
+    self.didUpdateCallback = didUpdateCallback
   }
 
   /// Returns the number of choices for the question
@@ -79,7 +84,7 @@ class QuestionDetailViewModel {
       hyperdrive.request(transition) { result in
         switch result {
         case .Success(let representor):
-          self.injectVoteResult(index, representor: representor)
+          self.update(choice: representor, index: index)
           completion(true)
         case .Failure(let error):
           println("Failed to vote \(error)")
@@ -92,19 +97,8 @@ class QuestionDetailViewModel {
   }
 
   /// Private methos for updating a choice at an index with the given representor
-  private func injectVoteResult(index:Int, representor:Representor<HTTPTransition>) {
-    var choices = self.choices
-    choices[index] = representor
-    var representor = self.representor
-
-    self.representor = Representor { builder in
-      for (key, value) in self.representor.attributes {
-        builder.addAttribute(key, value: value)
-      }
-
-      for choice in choices {
-        builder.addRepresentor("choices", representor: choice)
-      }
-    }
+  private func update(# choice:Representor<HTTPTransition>, index:Int) {
+    self.representor = self.representor.update("choices", representor: choice, index: index)
+    didUpdateCallback?(self.representor)
   }
 }

--- a/Polls/ViewModels/QuestionListViewModel.swift
+++ b/Polls/ViewModels/QuestionListViewModel.swift
@@ -121,7 +121,7 @@ class QuestionListViewModel {
   /// Returns a view model for creating a question if the user may create a question
   func createQuestionViewModel() -> CreateQuestionViewModel? {
     if let transition = representor?.transitions["create"] {
-      return CreateQuestionViewModel(hyperdrive: hyperdrive, transition: transition)
+      return CreateQuestionViewModel(hyperdrive: hyperdrive, transition: transition, didAddCallback: didAddQuestionRepresentor)
     }
 
     return nil
@@ -169,6 +169,38 @@ class QuestionListViewModel {
 
   /// Returns a view model for the given question index
   func questionDetailViewModel(index:Int) -> QuestionDetailViewModel {
-    return QuestionDetailViewModel(hyperdrive: hyperdrive, representor: questions![index])
+    return QuestionDetailViewModel(hyperdrive: hyperdrive, representor: questions![index], didUpdateCallback: didUpdateQuestionRepresentor(index))
+  }
+
+  // MARK: Callbacks
+
+  func didAddQuestionRepresentor(representor:Representor<HTTPTransition>) {
+    self.representor = self.representor?.insert("questions", representor: representor, index: 0)
+  }
+
+  func didUpdateQuestionRepresentor(index:Int)(representor:Representor<HTTPTransition>) {
+    self.representor = self.representor?.update("questions", representor: representor, index: index)
+  }
+}
+
+extension Representor {
+  func insert(relation:String, representor:Representor<Transition>, index:Int) -> Representor<Transition> {
+    var relatedRepresentors = self.representors[relation] ?? []
+    relatedRepresentors.insert(representor, atIndex: index)
+
+    var representors = self.representors
+    representors[relation] = relatedRepresentors
+
+    return Representor(transitions: transitions, representors: representors, attributes: attributes, metadata: metadata)
+  }
+
+  func update(relation:String, representor:Representor<Transition>, index:Int) -> Representor<Transition> {
+    var relatedRepresentors = self.representors[relation] ?? []
+    relatedRepresentors[index] = representor
+
+    var representors = self.representors
+    representors[relation] = relatedRepresentors
+
+    return Representor(transitions: transitions, representors: representors, attributes: attributes, metadata: metadata)
   }
 }


### PR DESCRIPTION
This pull request adds pull to request on the question detail screen if the server exposes a self transition. It will also update the question list when we vote too (fixing #14).