### PR TITLE
Allow NSAllowsArbitraryLoads

### DIFF
--- a/Polls/Info.plist
+++ b/Polls/Info.plist
@@ -38,5 +38,10 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
Any apps compiled against the iOS 9 SDK are subject to ATS (App Transport Security) which require https and TLS 1.2 or newer. This change disables that so that connections to non-https are allowed since this is an example application where you may want to connect to non-https hosts (such as a local development server).